### PR TITLE
1.14.1のORTを対象にし、`$ORT_RUST_STRATEGY`のデフォルトを`download`に

### DIFF
--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -13,7 +13,7 @@ use std::{
 /// WARNING: If version is changed, bindings for all platforms will have to be re-generated.
 ///          To do so, run this:
 ///              cargo build --package onnxruntime-sys --features generate-bindings
-const ORT_VERSION: &str = include_str!("../../VERSION_NUMBER");
+const ORT_VERSION: &str = "1.14.1";
 
 /// Base Url from which to download pre-built releases/
 const ORT_RELEASE_BASE_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download";
@@ -58,23 +58,9 @@ fn main() {
 }
 
 fn generate_bindings(include_dir: &Path) {
-    let clang_args = &[
-        format!("-I{}", include_dir.display()),
-        format!(
-            "-I{}",
-            include_dir
-                .join("onnxruntime")
-                .join("core")
-                .join("session")
-                .display()
-        ),
-    ];
+    let clang_args = &[format!("-I{}", include_dir.display())];
 
-    let path = include_dir
-        .join("onnxruntime")
-        .join("core")
-        .join("session")
-        .join("onnxruntime_c_api.h");
+    let path = include_dir.join("onnxruntime_c_api.h");
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
@@ -401,7 +387,7 @@ fn prepare_libort_dir() -> PathBuf {
         strategy.as_ref().map_or_else(|_| "unknown", String::as_str)
     );
     match strategy.as_ref().map(String::as_str) {
-        Ok("download") => prepare_libort_dir_prebuilt(),
+        Ok("download") | Err(_) => prepare_libort_dir_prebuilt(),
         Ok("system") => PathBuf::from(match env::var(ORT_RUST_ENV_SYSTEM_LIB_LOCATION) {
             Ok(p) => p,
             Err(e) => {
@@ -411,7 +397,7 @@ fn prepare_libort_dir() -> PathBuf {
                 );
             }
         }),
-        Ok("compile") | Err(_) => prepare_libort_dir_compiled(),
+        Ok("compile") => prepare_libort_dir_compiled(),
         _ => panic!("Unknown value for {:?}", ORT_RUST_ENV_STRATEGY),
     }
 }

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -411,7 +411,10 @@ fn prepare_libort_dir() -> PathBuf {
                 );
             }
         }),
-        Ok("compile") => prepare_libort_dir_compiled(),
+        Ok("compile") => panic!(
+            "`ORT_RUST_STRATEGY=compile` is currently unavailable. See \
+             https://github.com/VOICEVOX/onnxruntime/pull/2#discussion_r1150638175",
+        ),
         _ => panic!("Unknown value for {:?}", ORT_RUST_ENV_STRATEGY),
     }
 }

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -60,14 +60,14 @@ fn main() {
 fn generate_bindings(include_dir: &Path) {
     let clang_args = &[
         format!("-I{}", include_dir.display()),
-        //format!(
-        //    "-I{}",
-        //    include_dir
-        //        .join("onnxruntime")
-        //        .join("core")
-        //        .join("session")
-        //        .display()
-        //),
+        format!(
+            "-I{}",
+            include_dir
+                .join("onnxruntime")
+                .join("core")
+                .join("session")
+                .display()
+        ),
     ];
 
     let path = include_dir

--- a/rust/onnxruntime-sys/build.rs
+++ b/rust/onnxruntime-sys/build.rs
@@ -58,9 +58,23 @@ fn main() {
 }
 
 fn generate_bindings(include_dir: &Path) {
-    let clang_args = &[format!("-I{}", include_dir.display())];
+    let clang_args = &[
+        format!("-I{}", include_dir.display()),
+        //format!(
+        //    "-I{}",
+        //    include_dir
+        //        .join("onnxruntime")
+        //        .join("core")
+        //        .join("session")
+        //        .display()
+        //),
+    ];
 
-    let path = include_dir.join("onnxruntime_c_api.h");
+    let path = include_dir
+        //.join("onnxruntime")
+        //.join("core")
+        //.join("session")
+        .join("onnxruntime_c_api.h");
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for


### PR DESCRIPTION
### Description

<https://github.com/microsoft/onnxruntime/pull/12606>で追加されたRustバインディングに、まずは以下の変更を加えます。

- `main`ブランチのlibonnxruntimeを対象にしているので、`1.14.1`に固定する
- `$ORT_RUST_STRATEGY`のデフォルトが`compile`になっているので、旧onnxruntime-rsと同じ`download`に戻す
    "TODO"とありますし、~~これを見るにこのリポジトリの外では動かないと思います。~~
    <https://github.com/VOICEVOX/onnxruntime/blob/96b95a24eeec2c760dfd08b7ac98868860a890c0/rust/onnxruntime-sys/build.rs#L420>

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- <https://github.com/VOICEVOX/voicevox_core/issues/427>


